### PR TITLE
Fix bug: Add 'shelljs' installation to setup script and include npm run setup in start

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
         "build:scripts": "node scripts/build-scripts.js",
         "build:scss": "node scripts/build-scss.js",
         "clean": "node scripts/clean.js",
-        "start": "npm run build && node scripts/start.js",
-        "start:debug": "npm run build && node scripts/start-debug.js"
+        "start": "npm run setup && npm run build && node scripts/start.js",
+        "start:debug": "npm run build && node scripts/start-debug.js",
+        "setup": "npm install shelljs"
     },
     "description": "An HTML landing page template built with Bootstrap",
     "keywords": [
@@ -47,7 +48,7 @@
         "prettier": "2.8.6",
         "pug": "3.0.2",
         "sass": "1.60.0",
-        "shelljs": "0.8.5",
+        "shelljs": "^0.8.5",
         "upath": "2.0.1"
     }
 }


### PR DESCRIPTION
문제 : npm start시 Error: Cannot find module 'shelljs' 에러가 뜸
해결 : package.json 파일에 scripts에 "setup": "npm install shelljs" 를 추가한 뒤 start에 npm run setup을 추가.

=> 프로그램 실행시 자동으로 shelljs모듈을 설치하여 Error: Cannot find module 'shelljs 문제를 해결.